### PR TITLE
Fixed improper striping of code

### DIFF
--- a/PBXFileReference.m
+++ b/PBXFileReference.m
@@ -318,7 +318,7 @@
       NSString *buildTemplate = @"%@ %@ -c %@ %@ %@ -o %@";
       NSDebugLog(@"*** %@ %@", path, buildPath);
       NSString *compilePath = ([[[self buildPath] pathComponents] count] > 1)?
-        [[[self buildPath] stringByDeletingFirstPathComponent] stringByEscapingSpecialCharacters]:[self buildPath];
+        [[self buildPath] stringByEscapingSpecialCharacters]:[self buildPath];
       NSString *buildCommand = [NSString stringWithFormat: buildTemplate, 
 					 compiler,
 					 compilePath,


### PR DESCRIPTION
Call on line 321 improperly strips the leading string in the path, causing a fail when attempting to compile.