### PR TITLE
Replace nonportable function call

### DIFF
--- a/PBXProject.m
+++ b/PBXProject.m
@@ -210,7 +210,9 @@
 	  targetInSubdir = YES;
 	  chdir([[target name] UTF8String]);
           NSLog(@"Target dir = %@", [target name]);
-          char *cwd = get_current_dir_name();
+          const char *cwd = [[[NSFileManager defaultManager]
+			 currentDirectoryPath]
+			fileSystemRepresentation];
           NSLog(@"Changed dir to = %s", cwd);
 	  [context setObject: @"YES"
 		      forKey: @"TARGET_IN_SUBDIR"];
@@ -230,7 +232,9 @@
       // Back to the current dir...
       if(YES == targetInSubdir)
 	{
-          char *cwd = get_current_dir_name();
+          const char *cwd = [[[NSFileManager defaultManager]
+			 currentDirectoryPath]
+			fileSystemRepresentation];
           NSLog(@"Popped dir to = %s", cwd);
           NSLog(@"Current dir = %@", currentDirectory);
 	  chdir([currentDirectory UTF8String]);


### PR DESCRIPTION
PBXProject.m calls `get_current_dir_name()` which is a GNU extension and doesn't exist e.g. on FreeBSD. Here I use NSFileManager to find the cwd instead.