### PR TITLE
Use a default framework version if not filled by config

### DIFF
--- a/PBXNativeTarget.m
+++ b/PBXNativeTarget.m
@@ -133,7 +133,7 @@
       NSString *execName = [[fullPath lastPathComponent] stringByDeletingPathExtension];
       NSString *derivedSourceHeaderDir = [derivedSourceDir stringByAppendingPathComponent: execName];
       NSString *frameworkVersion = 
-	[NSString stringWithCString: getenv("FRAMEWORK_VERSION")];
+	[NSString stringWithCString: getenv("FRAMEWORK_VERSION") ?: "0.0.0"];
       [context setObject: [NSString stringWithString: fullPath]
 		  forKey: @"FRAMEWORK_DIR"];
 


### PR DESCRIPTION
Fixes #8.